### PR TITLE
Allow the chartReleaser workflow to be run manually

### DIFF
--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -6,6 +6,7 @@ on:
       - development
     paths:
       - helm/Chart.yaml
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
We need to be able to run this manually because the merge into development in the last PR didn't trigger the workflow to run (due to not changing Chart.yaml) so it's currently hosting the wrong version of the chart (the 2.0.3 version I created while testing rather than the 2.0.0 version the deployments are actually looking for).