### PR TITLE
Fix workflow package location

### DIFF
--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -24,4 +24,3 @@ jobs:
           charts_dir: ./
           charts_url: https://mhaswell-bcgov.github.io/NotifyBC/docs/helm/
           branch: gh-pages
-          target_dir: docs/helm

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -21,7 +21,6 @@ jobs:
         uses: stefanprodan/helm-gh-pages@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          charts_dir: docs/helm
-          charts_url: https://mhaswell-bcgov.github.io/NotifyBC/docs/helm/
+          charts_dir: ./
           branch: gh-pages
           target_dir: docs/helm

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -21,6 +21,7 @@ jobs:
         uses: stefanprodan/helm-gh-pages@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          charts_dir: ./
+          charts_dir: docs/helm
           charts_url: https://mhaswell-bcgov.github.io/NotifyBC/docs/helm/
           branch: gh-pages
+          target_dir: docs/helm


### PR DESCRIPTION
Fixed bug in workflow configuration causing the index.yaml to point to the wrong location for the chart .tgz files (was pointing to https://mhaswell-bcgov.github.io/NotifyBC/docs/helm/**docs/helm/**notify-bc-4.1.0.tgz instead of the correct path https://mhaswell-bcgov.github.io/NotifyBC/docs/helm/notify-bc-4.1.0.tgz for example).