### PR TITLE
Added includeForks option to renovate.json to allow Renovate to scan …

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "description": "Presets from https://github.com/bcgov/renovate-config",
   "extends": [
     "github>bcgov/renovate-config"
-  ]
+  ],
+  "includeForks": true
 }


### PR DESCRIPTION
From the Renovate job logs:
```
INFO: Repository is a fork and not manually configured - skipping - did you want to run with --fork-processing=enabled?
DEBUG: Removing any stale branches
DEBUG: config.repoIsOnboarded=undefined
DEBUG: No renovate branches found
DEBUG: Repository result: fork, status: disabled, enabled: false, onboarded: undefined
```
Hoping this option will allow the scan to go through.