### PR TITLE
Added support for PRs in chartReleaser workflow

### DIFF
--- a/.github/workflows/buildTestPublishContainerDeploy.yml
+++ b/.github/workflows/buildTestPublishContainerDeploy.yml
@@ -4,6 +4,8 @@ on:
     types:
       - published
   pull_request:
+    paths:
+      - 'src/**'
   workflow_dispatch:
 jobs:
   install-build-lint-and-test:

--- a/.github/workflows/buildTestPublishContainerDeploy.yml
+++ b/.github/workflows/buildTestPublishContainerDeploy.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     paths:
       - 'src/**'
+      - 'client/**'
+      - 'server/**'
+      - 'test/**'
+      - 'package-lock.json'
+      - 'Dockerfile'
   workflow_dispatch:
 jobs:
   install-build-lint-and-test:

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get helm chart version
         id: chart
-        run: "echo \"::set-output name=version::(helm show chart helm | grep 'version:' | cut -d' ' -f2)\""
+        run: "echo \"::set-output name=version::(helm show chart helm | grep 'version:' | cut -f2 -d' ')\""
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master
         with:

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get helm chart version
         id: chart
-        run: "echo \"::set-output name=version::$(helm show chart helm | grep 'version:' | cut -f2 -d' ')\""
+        run: "echo \"version=$(helm show chart helm | grep 'version:' | tail -1 | cut -f2 -d' ')\" >> $GITHUB_OUTPUT"
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master
         with:

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -18,7 +18,7 @@ jobs:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     env:
-      CHART_VERSION: "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.chart_version) || (github.event_name == 'pull_request' && github.event.pull_request.number) }}"
+      CHART_VERSION: "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.chart_version) || (github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number)) }}"
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get helm chart version
         id: chart
-        run: "echo \"::set-output name=version::(helm show chart helm | grep -o 'version: [^ ]*' | tail -1 | cut -d' ' -f 2)\""
+        run: "echo \"::set-output name=version::(helm show chart helm | grep 'version:' | tail -1 | cut -d' ' -f 2)\""
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master
         with:

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       chart_version:
-        description: 'The chart version to create. Will be appended to the current version from helm/Chart.yaml (eg. "pr36" on Chart.yaml version: 5.1.2 produces "5.1.2-pr36").'
+        description: 'The chart pre-release version label to create. Will be appended to the current version from helm/Chart.yaml (eg. Entering "pr36" with a helm/Chart.yaml at version 5.1.2 produces the final chart tag "5.1.2-pr36").'
         required: true
 
 jobs:

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get helm chart version
         id: chart
-        run: "echo \"::set-output name=version::(helm show chart helm | grep 'version:' | tail -1 | cut -d' ' -f 2)\""
+        run: "echo \"::set-output name=version::(helm show chart helm | grep 'version:' | cut -delimiter=' ' -fields=2)\""
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master
         with:

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get helm chart version
         id: chart
-        run: "echo \"::set-output name=version::(helm show chart helm | grep 'version:' | cut -f2 -d' ')\""
+        run: "echo \"::set-output name=version::$(helm show chart helm | grep 'version:' | cut -f2 -d' ')\""
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master
         with:
@@ -34,4 +34,4 @@ jobs:
           charts_dir: ./
           branch: gh-pages
           target_dir: helm
-          chart_version: ${{ format('{0}{1}', steps.chart.outputs.version, env.CHART_VERSION)  }}
+          chart_version: ${{ format('{0}{1}', steps.chart.outputs.version, env.CHART_VERSION || '') }}

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       chart_version:
-        description: 'The chart version to create. Must be a valid semver string and should indicate that it is not a release chart version (eg. 5.1.2-pr36).'
+        description: 'The chart version to create. Will be appended to the current version from Chart.yaml (eg. "pr36" on Chart.yaml version: 5.1.2 produces "5.1.2-pr36").'
         required: true
 
 jobs:
@@ -18,12 +18,15 @@ jobs:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     env:
-      CHART_VERSION: "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.chart_version) || (github.event_name == 'pull_request' && format('5.1.2-pr{0}', github.event.pull_request.number)) }}"
+      CHART_VERSION: "${{ (github.event_name == 'workflow_dispatch' && format('-{0}', github.event.inputs.chart_version)) || (github.event_name == 'pull_request' && format('-pr{0}', github.event.pull_request.number)) }}"
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Get helm chart version
+        id: chart
+        run: "echo \"::set-output name=version::(helm show chart helm | grep -o 'version: [^ ]*' | cut -d' ' -f 2)\""
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master
         with:
@@ -31,4 +34,4 @@ jobs:
           charts_dir: ./
           branch: gh-pages
           target_dir: helm
-          chart_version: ${{ env.CHART_VERSION || null }}
+          chart_version: ${{ format('{0}{1}', steps.chart.outputs.version, env.CHART_VERSION)  }}

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -4,6 +4,9 @@ on:
   release:
     types:
       - published
+  pull_request:
+    paths:
+      - 'helm/**'
   workflow_dispatch:
     inputs:
       chart_version:
@@ -15,7 +18,7 @@ jobs:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     env:
-      CHART_VERSION: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.chart_version || null }}"
+      CHART_VERSION: "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.chart_version) || (github.event_name == 'pull_request' && github.event.pull_request.number) }}"
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -28,4 +31,4 @@ jobs:
           charts_dir: ./
           branch: gh-pages
           target_dir: helm
-          chart_version: ${{ env.CHART_VERSION }}
+          chart_version: ${{ env.CHART_VERSION || null }}

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get helm chart version
         id: chart
-        run: "echo \"::set-output name=version::(helm show chart helm | grep 'version:' | cut -delimiter=' ' -fields=2)\""
+        run: "echo \"::set-output name=version::(helm show chart helm | grep 'version:' | cut -d' ' -f2)\""
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master
         with:

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -18,7 +18,7 @@ jobs:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     env:
-      CHART_VERSION: "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.chart_version) || (github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number)) }}"
+      CHART_VERSION: "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.chart_version) || (github.event_name == 'pull_request' && format('5.1.2-pr{0}', github.event.pull_request.number)) }}"
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get helm chart version
         id: chart
-        run: "echo \"::set-output name=version::(helm show chart helm | grep -o 'version: [^ ]*' | cut -d' ' -f 2)\""
+        run: "echo \"::set-output name=version::(helm show chart helm | grep -o 'version: [^ ]*' | tail -1 | cut -d' ' -f 2)\""
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master
         with:

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       chart_version:
-        description: 'The chart version to create. Will be appended to the current version from Chart.yaml (eg. "pr36" on Chart.yaml version: 5.1.2 produces "5.1.2-pr36").'
+        description: 'The chart version to create. Will be appended to the current version from helm/Chart.yaml (eg. "pr36" on Chart.yaml version: 5.1.2 produces "5.1.2-pr36").'
         required: true
 
 jobs:

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.1.2
+version: 5.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
- PRs automatically trigger temporary charts to be released using the current Chart.yaml version (eg. this PR automatically released a 5.1.2-pr42 chart). The workflow only runs automatically if files inside helm/ are changed
- The manual workflow run input no longer requires the user to input the entire chart version. It automatically takes the version from the Chart.yaml and appends the user input to it to create the tag. Because of this, we can no longer overwrite a release chart (eg. 5.1.2 with no hyphen) as the input won't allow it.
- It's still possible to overwrite a release chart by creating a GH Release and not updating the version in Chart.yaml to match the release tag.