### PR TITLE
Bug/descw 2469 chartreleaser release event

### DIFF
--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -18,7 +18,8 @@ jobs:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     env:
-      CHART_VERSION: "${{ (github.event_name == 'workflow_dispatch' && format('-{0}', github.event.inputs.chart_version)) || (github.event_name == 'pull_request' && format('-pr{0}', github.event.pull_request.number)) }}"
+      #CHART_VERSION: "${{ (github.event_name == 'workflow_dispatch' && format('-{0}', github.event.inputs.chart_version)) || (github.event_name == 'pull_request' && format('-pr{0}', github.event.pull_request.number)) }}"
+      CHART_VERSION: "${{ (false) }}" # Testing no return value (occurs for release event)
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -34,4 +35,4 @@ jobs:
           charts_dir: ./
           branch: gh-pages
           target_dir: helm
-          chart_version: ${{ format('{0}{1}', steps.chart.outputs.version, env.CHART_VERSION || '') }}
+          chart_version: ${{ format('{0}{1}', steps.chart.outputs.version, (env.CHART_VERSION != 'false' && env.CHART_VERSION || '')) }}

--- a/.github/workflows/chartReleaser.yml
+++ b/.github/workflows/chartReleaser.yml
@@ -18,8 +18,7 @@ jobs:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     env:
-      #CHART_VERSION: "${{ (github.event_name == 'workflow_dispatch' && format('-{0}', github.event.inputs.chart_version)) || (github.event_name == 'pull_request' && format('-pr{0}', github.event.pull_request.number)) }}"
-      CHART_VERSION: "${{ (false) }}" # Testing no return value (occurs for release event)
+      CHART_VERSION: "${{ (github.event_name == 'workflow_dispatch' && format('-{0}', github.event.inputs.chart_version)) || (github.event_name == 'pull_request' && format('-pr{0}', github.event.pull_request.number)) }}"
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
See failed run [here](https://github.com/bcgov/des-notifybc/actions/runs/9977627681/job/27572703121) caused by `env.CHART_VERSION: false` creating a final chart tag of `5.1.3false` (not a valid semver version).
And a successful run with the fix producing the intended chart tag `5.1.3` [here.](https://github.com/bcgov/des-notifybc/actions/runs/10064050294/job/27820163554) 