### PR TITLE
Fixed error in Mongoose connection using unsupported option "dbpath" …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -253,9 +253,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.2.tgz",
-      "integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+      "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -301,12 +301,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
-      "integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+      "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.25.0",
+        "@babel/types": "^7.25.6",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -421,13 +421,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
+      "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/types": "^7.25.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -520,12 +520,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
-      "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+      "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.25.2"
+        "@babel/types": "^7.25.6"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -586,12 +586,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.7.tgz",
-      "integrity": "sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.6.tgz",
+      "integrity": "sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -742,12 +742,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
-      "integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
+      "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -771,16 +771,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.3.tgz",
-      "integrity": "sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+      "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
+        "@babel/generator": "^7.25.6",
+        "@babel/parser": "^7.25.6",
         "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.2",
+        "@babel/types": "^7.25.6",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -798,9 +798,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+      "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.24.8",
@@ -1578,9 +1578,9 @@
       }
     },
     "node_modules/@nestjs/cli": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.4.tgz",
-      "integrity": "sha512-WKERbSZJGof0+9XeeMmWnb/9FpNxogcB5eTJTHjc9no0ymdTw3jTzT+KZL9iC/hGqBpuomDLaNFCYbAOt29nBw==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.5.tgz",
+      "integrity": "sha512-FP7Rh13u8aJbHe+zZ7hM0CC4785g9Pw4lz4r2TTgRtf0zTxSWMkJaPEwyjX8SK9oWK2GsYxl+fKpwVZNbmnj9A==",
       "dev": true,
       "dependencies": {
         "@angular-devkit/core": "17.3.8",
@@ -1600,7 +1600,7 @@
         "tsconfig-paths": "4.2.0",
         "tsconfig-paths-webpack-plugin": "4.1.0",
         "typescript": "5.3.3",
-        "webpack": "5.93.0",
+        "webpack": "5.94.0",
         "webpack-node-externals": "3.0.0"
       },
       "bin": {
@@ -1760,9 +1760,9 @@
       }
     },
     "node_modules/@nestjs/schematics": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.1.3.tgz",
-      "integrity": "sha512-aLJ4Nl/K/u6ZlgLa0NjKw5CuBOIgc6vudF42QvmGueu5FaMGM6IJrAuEvB5T2kr0PAfVwYmDFBBHCWdYhTw4Tg==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.1.4.tgz",
+      "integrity": "sha512-QpY8ez9cTvXXPr3/KBrtSgXQHMSV6BkOUYy2c2TTe6cBqriEdGnCYqGl8cnfrQl3632q3lveQPaZ/c127dHsEw==",
       "dev": true,
       "dependencies": {
         "@angular-devkit/core": "17.3.8",
@@ -2102,26 +2102,6 @@
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
-      "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -2231,11 +2211,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.15.tgz",
-      "integrity": "sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==",
+      "version": "20.16.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.2.tgz",
+      "integrity": "sha512-91s/n4qUPV/wg8eE9KHYW1kouTfDk2FPGjXbBMfRWP/2vg1rCXNQL1OCabwGs0XSdukuK+MwCDXE30QpSeMUhQ==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/qs": {
@@ -2284,9 +2264,9 @@
       "dev": true
     },
     "node_modules/@types/superagent": {
-      "version": "8.1.8",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.8.tgz",
-      "integrity": "sha512-nTqHJ2OTa7PFEpLahzSEEeFeqbMpmcN7OeayiOc7v+xk+/vyTKljRe+o4MPqSnPeRCMvtxuLG+5QqluUVQJOnA==",
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
       "dev": true,
       "dependencies": {
         "@types/cookiejar": "^2.1.5",
@@ -2305,9 +2285,9 @@
       }
     },
     "node_modules/@types/validator": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.0.tgz",
-      "integrity": "sha512-nH45Lk7oPIJ1RVOF6JgFI6Dy0QpHEzq4QecZhvguxYPDwT8c93prCMqAtiIttm39voZ+DDR+qkNnMpJmMBRqag=="
+      "version": "13.12.1",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.1.tgz",
+      "integrity": "sha512-w0URwf7BQb0rD/EuiG12KP0bailHKHP5YVviJG9zw3ykAokL0TuxU2TUqMB7EwZ59bDHYdeTIvjI5m0S7qHfOA=="
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -2941,9 +2921,9 @@
       "dev": true
     },
     "node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "node_modules/async-mutex": {
       "version": "0.4.1",
@@ -2959,9 +2939,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -3434,9 +3414,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001651",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
-      "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
+      "version": "1.0.30001655",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001655.tgz",
+      "integrity": "sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==",
       "dev": true,
       "funding": [
         {
@@ -3549,9 +3529,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
-      "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.0.tgz",
+      "integrity": "sha512-N1NGmowPlGBLsOZLPvm48StN04V4YvQRL0i6b7ctrVY3epjP/ct7hFLOItz6pDIvRjwpfPxi52a2UWV2ziir8g==",
       "dev": true
     },
     "node_modules/class-transformer": {
@@ -4007,9 +3987,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.12",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
-      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg=="
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.3.6",
@@ -4270,9 +4250,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.7.tgz",
-      "integrity": "sha512-6FTNWIWMxMy/ZY6799nBlPtF1DFDQ6VQJ7yyDP27SJNt5lwtQ5ufqVvHylb3fdQefvRcgA3fKcFMJi9OLwBRNw==",
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4376,9 +4356,9 @@
       "dev": true
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -5908,9 +5888,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
@@ -6992,9 +6972,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.5.tgz",
-      "integrity": "sha512-TwHR5BZxGRODtAfz03szucAkjT5OArXr+94SMtAM2pYXIlQNVMrxvb6uSCbnaJJV6QXEyICk7+l6QPgn72WHhg=="
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.7.tgz",
+      "integrity": "sha512-x2xON4/Qg2bRIS11KIN9yCNYUjhtiEjNyptjX0mX+pyKHecxuJVLIpfX1lq9ZD6CrC/rB+y4GBi18c6CEcUR+A=="
     },
     "node_modules/libqp": {
       "version": "2.1.0",
@@ -7358,9 +7338,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
@@ -7549,34 +7529,34 @@
       }
     },
     "node_modules/mongodb-memory-server": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-9.4.1.tgz",
-      "integrity": "sha512-qONlW4sKPbtk9pqFnlPn7R73G3Q4TuebJJ5pHfoiKTqVJquojQ8xWmkCyz+/YnpA2vYBo/jib+nXvjfKwh7cjg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-9.2.0.tgz",
+      "integrity": "sha512-w/usKdYtby5EALERxmA0+et+D0brP0InH3a26shNDgGefXA61hgl6U0P3IfwqZlEGRZdkbZig3n57AHZgDiwvg==",
       "hasInstallScript": true,
       "dependencies": {
-        "mongodb-memory-server-core": "9.4.1",
-        "tslib": "^2.6.3"
+        "mongodb-memory-server-core": "9.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.20.1"
       }
     },
     "node_modules/mongodb-memory-server-core": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.4.1.tgz",
-      "integrity": "sha512-lobapXaysH64zrn521NTkmqHc3krSPUFkuuZ8A/BmQV8ON7p2SzAEvpoJPDXIeJkxIzYw06dYL6Gn5OcZdEElA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.2.0.tgz",
+      "integrity": "sha512-9SWZEy+dGj5Fvm5RY/mtqHZKS64o4heDwReD4SsfR7+uNgtYo+JN41kPCcJeIH3aJf04j25i5Dia2s52KmsMPA==",
       "dependencies": {
-        "async-mutex": "^0.4.1",
+        "async-mutex": "^0.4.0",
         "camelcase": "^6.3.0",
-        "debug": "^4.3.5",
+        "debug": "^4.3.4",
         "find-cache-dir": "^3.3.2",
         "follow-redirects": "^1.15.6",
         "https-proxy-agent": "^7.0.4",
-        "mongodb": "^5.9.2",
+        "mongodb": "^5.9.1",
         "new-find-package-json": "^2.0.0",
-        "semver": "^7.6.2",
+        "semver": "^7.6.0",
         "tar-stream": "^3.1.7",
-        "tslib": "^2.6.3",
+        "tslib": "^2.6.2",
         "yauzl": "^3.1.3"
       },
       "engines": {
@@ -7584,9 +7564,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.0.tgz",
-      "integrity": "sha512-wLAP7xYz+tEnzy4VsZyMJ1mfaSIwfaeoSQ55ZVovFkdh1FVta6VNSVFCpJMzEinMJsRzTbZTcD4pND9J5aDiyA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.1.tgz",
+      "integrity": "sha512-c3MY8P1mGUGO+0H8rqxMNmAmhP0xb2EPNItfr7tHAHkh52uB0owH4Gu6q1GTUYj8yoHEDG5MN2V1aBBR6aJPuA==",
       "dependencies": {
         "bson": "^5.5.0",
         "kareem": "2.5.1",
@@ -9145,9 +9125,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
-      "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.0.tgz",
+      "integrity": "sha512-ZGd1LhDeGFucr1CUCTBOS58ZhEendd0ttpGT3usTvosS4ntIwKN9LJFp+OeCSprsCPL14BXVRZlHGRY1V9PVzQ==",
       "dependencies": {
         "fast-fifo": "^1.3.2",
         "queue-tick": "^1.0.1",
@@ -9628,20 +9608,20 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.2.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.4.tgz",
-      "integrity": "sha512-3d6tgDyhCI29HlpwIq87sNuI+3Q6GLTTCeYRHCs7vDz+/3GCMwEtV9jezLyl4ZtnBgx00I7hm8PCP8cTksMGrw==",
+      "version": "29.2.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
+      "integrity": "sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==",
       "dev": true,
       "dependencies": {
-        "bs-logger": "0.x",
+        "bs-logger": "^0.2.6",
         "ejs": "^3.1.10",
-        "fast-json-stable-stringify": "2.x",
+        "fast-json-stable-stringify": "^2.1.0",
         "jest-util": "^29.0.0",
         "json5": "^2.2.3",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "^7.5.3",
-        "yargs-parser": "^21.0.1"
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.6.3",
+        "yargs-parser": "^21.1.1"
       },
       "bin": {
         "ts-jest": "cli.js"
@@ -9782,9 +9762,9 @@
       "dev": true
     },
     "node_modules/twilio": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-5.2.2.tgz",
-      "integrity": "sha512-t2Nd8CvqAc0YxbJghKYQl1Vxc7e6SrWk4U28wwkarUohGcsUMLsGpYeGXKw1Va0KB9TGVZYCs8dcP4TdLJUN9Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-5.2.3.tgz",
+      "integrity": "sha512-mJRRHdYnNoHLvbFTBGzYgSNe4RMQDQn3vfE8O6NaSbn2GKUPm6n87gfurqB9QHW2G4SZ7Ge3BKM2roqCMqHSbg==",
       "dependencies": {
         "axios": "^1.6.8",
         "dayjs": "^1.11.9",
@@ -9912,9 +9892,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -10070,12 +10050,11 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.93.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
-      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
@@ -10084,7 +10063,7 @@
         "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,27 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Logger, MiddlewareConsumer, Module } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
-import { MongoMemoryReplSet } from 'mongodb-memory-server';
-import { AdministratorsModule } from './api/administrators/administrators.module';
-import { BouncesModule } from './api/bounces/bounces.module';
-import { BaseController } from './api/common/base.controller';
-import { ConfigurationsModule } from './api/configurations/configurations.module';
-import { NotificationsModule } from './api/notifications/notifications.module';
-import { SubscriptionsModule } from './api/subscriptions/subscriptions.module';
-import { AppService } from './app.service';
-import { AuthModule } from './auth/auth.module';
-import { AppConfigService } from './config/app-config.service';
-import { ConfigModule } from './config/config.module';
-import { DbConfigService } from './config/db-config.service';
-import { MiddlewareConfigService } from './config/middleware-config.service';
-import { ObserversModule } from './observers/observers.module';
-import { ShutdownService } from './observers/shutdown.service';
-import { SwaggerService } from './observers/swagger.service';
-import { RssModule } from './rss/rss.module';
-import { HealthModule } from './api/health/health.module';
-import { MemoryModule } from './api/memory/memory.module';
+import {Logger, MiddlewareConsumer, Module} from '@nestjs/common';
+import {MongooseModule} from '@nestjs/mongoose';
+import {MongoMemoryReplSet} from 'mongodb-memory-server';
+import {AdministratorsModule} from './api/administrators/administrators.module';
+import {BouncesModule} from './api/bounces/bounces.module';
+import {BaseController} from './api/common/base.controller';
+import {ConfigurationsModule} from './api/configurations/configurations.module';
+import {HealthModule} from './api/health/health.module';
+import {MemoryModule} from './api/memory/memory.module';
+import {NotificationsModule} from './api/notifications/notifications.module';
+import {SubscriptionsModule} from './api/subscriptions/subscriptions.module';
+import {AppService} from './app.service';
+import {AuthModule} from './auth/auth.module';
+import {AppConfigService} from './config/app-config.service';
+import {ConfigModule} from './config/config.module';
+import {DbConfigService} from './config/db-config.service';
+import {MiddlewareConfigService} from './config/middleware-config.service';
+import {ObserversModule} from './observers/observers.module';
+import {ShutdownService} from './observers/shutdown.service';
+import {SwaggerService} from './observers/swagger.service';
+import {RssModule} from './rss/rss.module';
 
 @Module({
   imports: [
@@ -51,7 +51,7 @@ import { MemoryModule } from './api/memory/memory.module';
         shutdownService: ShutdownService,
       ) => {
         const dbConfig = dbConfigService.get();
-        if (dbConfig.uri) return { ...dbConfig, autoIndex: false };
+        if (dbConfig.uri) return {...dbConfig, autoIndex: false};
         const mongod = await MongoMemoryReplSet.create({
           instanceOpts: [dbConfig],
         });
@@ -59,7 +59,6 @@ import { MemoryModule } from './api/memory/memory.module';
         shutdownService.addMongoDBServer(mongod);
         Logger.log(`mongodb-memory-server started at ${uri}`, AppModule.name);
         return {
-          ...dbConfig,
           autoIndex: false,
           uri,
         };
@@ -90,7 +89,7 @@ export class AppModule {
     for (const middlewareFactoryNm in apiOnlyMiddlewareConfigs) {
       if (apiOnlyMiddlewareConfigs[middlewareFactoryNm].enabled === false)
         continue;
-      const { default: m } = await import(middlewareFactoryNm);
+      const {default: m} = await import(middlewareFactoryNm);
       apiOnlyMiddlewares.push(
         m.apply(this, apiOnlyMiddlewareConfigs[middlewareFactoryNm].params),
       );

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Logger, ValidationPipe } from '@nestjs/common';
-import { NestFactory } from '@nestjs/core';
+import {Logger, ValidationPipe} from '@nestjs/common';
+import {NestFactory} from '@nestjs/core';
 import {
   ExpressAdapter,
   NestExpressApplication,
@@ -23,12 +23,12 @@ import express from 'express';
 import https from 'https';
 import os from 'os';
 import path from 'path';
-import { ErrorsInterceptor } from './api/common/errors.interceptor';
-import { AppModule } from './app.module';
-import { AppService } from './app.service';
-import { AppConfigService } from './config/app-config.service';
-import { MiddlewareAllService } from './observers/middleware-all.service';
-import { ShutdownService } from './observers/shutdown.service';
+import {ErrorsInterceptor} from './api/common/errors.interceptor';
+import {AppModule} from './app.module';
+import {AppService} from './app.service';
+import {AppConfigService} from './config/app-config.service';
+import {MiddlewareAllService} from './observers/middleware-all.service';
+import {ShutdownService} from './observers/shutdown.service';
 const logger = new Logger(path.parse(__filename).name);
 
 // setupApp is shared between bootstrap and e2e setupApplication
@@ -65,9 +65,9 @@ async function bootstrap() {
   const host = appConfig.host ?? '0.0.0.0';
   const proto = appConfig.tls?.enabled ? 'https' : 'http';
   if (appConfig.tls?.enabled) {
-    let opts = { ...appConfig.tls };
+    let opts = {...appConfig.tls};
     if (appConfig.tls?.clientCertificateEnabled) {
-      opts = { ...opts, requestCert: true, rejectUnauthorized: false };
+      opts = {...opts, requestCert: true, rejectUnauthorized: false};
     }
     await new Promise((resolve) => {
       const shutdownService = app.get(ShutdownService);
@@ -86,7 +86,7 @@ async function bootstrap() {
 }
 
 if (require.main === module) {
-  let numWorkers = parseInt(process.env.NOTIFYBC_WORKER_PROCESS_COUNT ?? '');
+  let numWorkers = parseInt(process.env.NOTIFYBC_WORKER_PROCESS_COUNT ?? '1');
   if (isNaN(numWorkers)) {
     numWorkers = os.cpus().length;
   }
@@ -112,7 +112,7 @@ if (require.main === module) {
         }
       }
 
-      cluster.on('exit', (worker: { process: { pid: any } }) => {
+      cluster.on('exit', (worker: {process: {pid: any}}) => {
         logger.log(`worker ${worker.process.pid} died`);
         if (worker === masterWorker) {
           logger.log(`worker ${worker.process.pid} is the master worker`);

--- a/src/observers/cron.service.ts
+++ b/src/observers/cron.service.ts
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Injectable, OnApplicationBootstrap} from '@nestjs/common';
-import {CronJob} from 'cron';
-import {AppConfigService} from 'src/config/app-config.service';
-import {CronTasksService} from './cron-tasks.service';
+import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { CronJob } from 'cron';
+import { AppConfigService } from 'src/config/app-config.service';
+import { CronTasksService } from './cron-tasks.service';
 
 @Injectable()
 export class CronService implements OnApplicationBootstrap {
@@ -41,7 +41,7 @@ export class CronService implements OnApplicationBootstrap {
     this.jobs.push(
       CronJob.from({
         cronTime: cronConfigPurgeData.timeSpec,
-        onTick: async() => {
+        onTick: async () => {
           await this.cronTasksService.purgeData();
         },
         start: true,
@@ -53,7 +53,7 @@ export class CronService implements OnApplicationBootstrap {
     this.jobs.push(
       CronJob.from({
         cronTime: cronConfigDispatchLiveNotifications.timeSpec,
-        onTick: async() => {
+        onTick: async () => {
           await this.cronTasksService.dispatchLiveNotifications();
         },
         start: true,
@@ -87,7 +87,7 @@ export class CronService implements OnApplicationBootstrap {
     this.jobs.push(
       CronJob.from({
         cronTime: reDispatchBroadcastPushNotifications.timeSpec,
-        onTick: async() => {
+        onTick: async () => {
           await this.cronTasksService.reDispatchBroadcastPushNotifications();
         },
         start: true,
@@ -106,7 +106,7 @@ export class CronService implements OnApplicationBootstrap {
       this.jobs.push(
         CronJob.from({
           cronTime: clearRedisDatastore.timeSpec,
-          onTick: async() => {
+          onTick: async () => {
             await this.cronTasksService.clearRedisDatastore();
           },
           start: true,


### PR DESCRIPTION
…from db.datasource.ts

Set default of 1 for `NOTIFYBC_WORKER_PROCESS_COUNT` to avoid "DBPathInUse: Unable to lock the lock file" error when using multiple workers
Minor linting fixes fixed automatically by `npm run lint`

Non-linting changes are here:

- Removing dbConfig from connection object: https://github.com/bcgov/des-notifybc/pull/58/files#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8L62
- Setting default worker count to 1: https://github.com/bcgov/des-notifybc/pull/58/files#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8L62