### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ghPages.yml
+++ b/.github/workflows/ghPages.yml
@@ -1,4 +1,7 @@
 name: Publish to GH Pages
+permissions:
+  contents: write
+  pages: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/des-notifybc/security/code-scanning/34](https://github.com/bcgov/des-notifybc/security/code-scanning/34)

To fix the issue, we will add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Based on the workflow's operations, the following permissions are needed:
- `contents: write` for deploying to GitHub Pages.
- `pages: write` for requesting a GitHub Pages build.

This ensures that the workflow has only the permissions it needs to function correctly, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
