### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildImageOnPush.yaml
+++ b/.github/workflows/buildImageOnPush.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'src/**'
   workflow_dispatch:
+permissions:
+  contents: read
 defaults:
   run:
     working-directory: ./


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/des-notifybc/security/code-scanning/36](https://github.com/bcgov/des-notifybc/security/code-scanning/36)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required. Based on the workflow's steps, it primarily interacts with the repository's contents (e.g., checking out code) and does not perform any write operations. Therefore, we will set `contents: read` as the minimal required permission. This change ensures that the workflow operates securely and adheres to GitHub's best practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
