### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildTestPublishContainerDeploy.yml
+++ b/.github/workflows/buildTestPublishContainerDeploy.yml
@@ -1,4 +1,6 @@
 name: buildTestPublishContainerDeploy
+permissions:
+  contents: read
 on:
   release:
     types:
@@ -33,6 +35,9 @@ jobs:
     if: ${{ github.repository == 'bcgov/des-notifybc' && github.actor != 'renovate[bot]' }}
     needs: install-build-lint-and-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4.2.2
@@ -67,6 +72,9 @@ jobs:
     if: ${{ github.repository == 'bcgov/des-notifybc' && github.event_name == 'push' }}
     needs: publish-container
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/des-notifybc/security/code-scanning/38](https://github.com/bcgov/des-notifybc/security/code-scanning/38)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required for the workflow. Based on the steps in the workflow:

1. The `install-build-lint-and-test` job only needs `contents: read` to check out the repository.
2. The `publish-container` job requires `contents: read` for checkout and `packages: write` to publish the container to the GitHub Container Registry.
3. The `deploy` job requires `contents: read` for checkout and `id-token: write` for authentication with OpenShift.

We will add a `permissions` block at the workflow level to set `contents: read` as the default and override it at the job level where additional permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
