### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildTestPublishContainerDeploy.yml
+++ b/.github/workflows/buildTestPublishContainerDeploy.yml
@@ -1,4 +1,8 @@
 name: buildTestPublishContainerDeploy
+permissions:
+  contents: read
+  packages: write
+  id-token: write
 on:
   release:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/des-notifybc/security/code-scanning/37](https://github.com/bcgov/des-notifybc/security/code-scanning/37)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required for the workflow. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `packages: write` for publishing the container to the GitHub Container Registry.
- `id-token: write` for authentication with OpenID Connect (OIDC) if required by any of the actions.

This change will ensure that the `GITHUB_TOKEN` has only the permissions needed for the workflow to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
