### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildTestPublishContainerDeploy.yml
+++ b/.github/workflows/buildTestPublishContainerDeploy.yml
@@ -1,4 +1,8 @@
 name: buildTestPublishContainerDeploy
+permissions:
+  contents: read
+  packages: write
+  deployments: write
 on:
   release:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/des-notifybc/security/code-scanning/35](https://github.com/bcgov/des-notifybc/security/code-scanning/35)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for the workflow. Based on the workflow's steps:
- The `install-build-lint-and-test` job only needs `contents: read` to check out the repository and run tests.
- The `publish-container` job requires `contents: read` and `packages: write` to publish the container to the GitHub Container Registry.
- The `deploy` job requires `contents: read` and possibly `deployments: write` to interact with the deployment process.

We will add these permissions explicitly to ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
