### PR TITLE
Potential fix for code scanning alert no. 17: Regular expression injection

### DIFF
--- a/src/api/subscriptions/subscriptions.controller.ts
+++ b/src/api/subscriptions/subscriptions.controller.ts
@@ -43,7 +43,7 @@ import {
 } from '@nestjs/swagger';
 import crypto from 'crypto';
 import { Request, Response } from 'express';
-import { merge } from 'lodash';
+import { merge, escapeRegExp } from 'lodash';
 import { AnyObject, FilterQuery } from 'mongoose';
 import RandExp from 'randexp';
 import { Role } from 'src/auth/constants';
@@ -153,7 +153,8 @@ export class SubscriptionsController extends BaseController {
       if (!body.PhoneNumber) {
         throw new HttpException(undefined, HttpStatus.FORBIDDEN);
       }
-      const phoneNumberArr = body.PhoneNumber.split('');
+      const sanitizedPhoneNumber = _.escapeRegExp(body.PhoneNumber);
+      const phoneNumberArr = sanitizedPhoneNumber.split('');
       // country code is optional
       if (phoneNumberArr[0] === '1') {
         phoneNumberArr[0] = '1?';


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/des-notifybc/security/code-scanning/17](https://github.com/bcgov/des-notifybc/security/code-scanning/17)

To fix the issue, we need to sanitize the user input before constructing the regular expression. The best approach is to use a library like `lodash` and its `_.escapeRegExp` function to escape any special characters in the user input. This ensures that the input cannot introduce unintended behavior into the regular expression.

Specifically:
1. Import the `escapeRegExp` function from `lodash`.
2. Apply `escapeRegExp` to `body.PhoneNumber` before splitting it into characters.
3. Use the sanitized version of the phone number to construct the regular expression.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
