### PR TITLE
Potential fix for code scanning alert no. 18: Regular expression injection

### DIFF
--- a/src/api/subscriptions/subscriptions.controller.ts
+++ b/src/api/subscriptions/subscriptions.controller.ts
@@ -43,7 +43,7 @@ import {
 } from '@nestjs/swagger';
 import crypto from 'crypto';
 import { Request, Response } from 'express';
-import { merge } from 'lodash';
+import { merge, escapeRegExp as _escapeRegExp } from 'lodash';
 import { AnyObject, FilterQuery } from 'mongoose';
 import RandExp from 'randexp';
 import { Role } from 'src/auth/constants';
@@ -989,9 +989,10 @@ export class SubscriptionsController extends BaseController {
       !data.confirmationRequest.confirmationCode &&
       data.confirmationRequest.confirmationCodeRegex
     ) {
-      const confirmationCodeRegex = new RegExp(
+      const safeRegex = _.escapeRegExp(
         data.confirmationRequest.confirmationCodeRegex,
       );
+      const confirmationCodeRegex = new RegExp(safeRegex);
       data.confirmationRequest.confirmationCode = new RandExp(
         confirmationCodeRegex,
       ).gen();


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/des-notifybc/security/code-scanning/18](https://github.com/bcgov/des-notifybc/security/code-scanning/18)

To fix the issue, the user-provided input (`data.confirmationRequest.confirmationCodeRegex`) must be sanitized before being used to construct a `RegExp` object. The best approach is to use a library like `lodash` and its `_.escapeRegExp` function to escape special characters in the input, ensuring that it cannot introduce malicious patterns. This fix should be applied in the `beforeUpsert` method of `SubscriptionsController`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
