### PR TITLE
Potential fix for code scanning alert no. 21: Database query built from user-controlled sources

### DIFF
--- a/src/api/administrators/administrators.service.ts
+++ b/src/api/administrators/administrators.service.ts
@@ -33,9 +33,12 @@ export class AdministratorsService extends BaseService<Administrator> {
   async verifyCredentials(credentials: LoginDto): Promise<Administrator> {
     const invalidCredentialsError = 'Invalid email or password.';
 
+    if (typeof credentials.email !== 'string') {
+      throw new HttpException(invalidCredentialsError, HttpStatus.UNAUTHORIZED);
+    }
     const foundUser = await this.model
       .findOne({
-        email: credentials.email,
+        email: { $eq: credentials.email },
       })
       .populate('userCredential')
       .exec();


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/des-notifybc/security/code-scanning/21](https://github.com/bcgov/des-notifybc/security/code-scanning/21)

To fix the issue, we need to ensure that the `credentials.email` field is properly sanitized or validated before it is used in the MongoDB query. The best approach is to use MongoDB's `$eq` operator to ensure that the user-provided value is treated as a literal value and not as a query object. Additionally, we can add a type-check to ensure that `credentials.email` is a string.

Steps to implement the fix:
1. Modify the `verifyCredentials` method in `src/api/administrators/administrators.service.ts` to use the `$eq` operator in the query.
2. Add a type-check to ensure that `credentials.email` is a string before using it in the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
