### PR TITLE
Potential fix for code scanning alert no. 22: Database query built from user-controlled sources

### DIFF
--- a/src/api/common/base.service.ts
+++ b/src/api/common/base.service.ts
@@ -70,8 +70,18 @@ export class BaseService<T> {
       updateDto.updatedBy = req.user;
     }
     updateDto.updated = new Date();
+
+    // Validate and sanitize updateDto
+    const allowedFields = ['field1', 'field2', 'updatedBy', 'updated']; // Replace with actual allowed fields
+    const sanitizedUpdateDto = Object.keys(updateDto)
+      .filter(key => allowedFields.includes(key))
+      .reduce((obj, key) => {
+        obj[key] = updateDto[key];
+        return obj;
+      }, {});
+
     const res = await this.model
-      .updateMany(this.model.translateAliases(filter), updateDto)
+      .updateMany(this.model.translateAliases(filter), { $set: sanitizedUpdateDto })
       .exec();
     return { count: res.modifiedCount };
   }


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/des-notifybc/security/code-scanning/22](https://github.com/bcgov/des-notifybc/security/code-scanning/22)

To fix the issue, we need to ensure that the `updateDto` object is sanitized or validated before it is used in the `updateMany` query. This can be achieved by:
1. Validating the structure and content of `updateDto` to ensure it only contains expected fields and values.
2. Using Mongoose's `$set` operator to explicitly define which fields should be updated, preventing the user from injecting malicious query operators.

The fix will involve:
- Adding a validation or sanitization step for `updateDto` in the `updateAll` method of `BaseService`.
- Ensuring that only allowed fields are included in the update operation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
