### PR TITLE
Potential fix for code scanning alert no. 14: Server-side request forgery

### DIFF
--- a/src/api/notifications/notifications.controller.ts
+++ b/src/api/notifications/notifications.controller.ts
@@ -738,6 +738,15 @@ export class NotificationsController extends BaseController {
                 this.req.protocol + '://' + this.req.get('host');
             }
 
+            // Validate httpHost against an allow-list of trusted hosts
+            const trustedHosts = this.appConfig.trustedHosts || [];
+            if (!trustedHosts.some((trustedHost) => httpHost.startsWith(trustedHost))) {
+              throw new HttpException(
+                'Invalid host specified',
+                HttpStatus.BAD_REQUEST,
+              );
+            }
+
             const q = queue(async (task: { startIdx: string }) => {
               const uri =
                 httpHost +


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/des-notifybc/security/code-scanning/14](https://github.com/bcgov/des-notifybc/security/code-scanning/14)

To fix the SSRF vulnerability, we need to ensure that the `httpHost` value is validated or restricted to a predefined allow-list of trusted hosts. This prevents attackers from injecting malicious URLs via the `Host` header or other user-controlled inputs.

**Steps to fix:**
1. Introduce an allow-list of trusted hosts in the application configuration.
2. Validate the `httpHost` value against this allow-list before using it to construct the `uri`.
3. If the `httpHost` value is not in the allow-list, reject the request or use a default trusted host.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
