### PR TITLE
Potential fix for code scanning alert no. 14: Server-side request forgery

### DIFF
--- a/NOTIFY-117.md
+++ b/NOTIFY-117.md
@@ -1,0 +1,190 @@
+# NOTIFY MONTHLY MAINTENANCE REPORT - June 20, 2025
+
+**JIRA Ticket:** [NOTIFY-117](https://citz-gdx.atlassian.net/browse/NOTIFY-117)
+**Maintenance Period:** June 30, 2025 - July 30, 2025
+**Completed By:** Richard OBrien
+**Completion Date:** July 30, 2025
+
+---
+
+## 1. Dependabot and Renovate Review
+
+### Dependabot PRs - Merged ✅
+
+| PR # | Title | Type | Notes |
+|------|-------|------|-------|
+| #113 | [Bump multer and @nestjs/platform-express](https://github.com/bcgov/des-notifybc/pull/113) | Security/Dependency | version update |
+| #XXX | [PR Title](link) | Formidable relies on hexoid to prevent guessing of filenames for untrusted executable content | Dependabot cannot update formidable to a non-vulnerable version |
+| #107 | [PR Title](link) | Security/Dependency | [Brief description] |
+
+**Total Merged:** X PRs
+
+### Dependabot PRs - Manual Intervention Required ⚠️
+
+| PR # | Title | Issue | Action Taken |
+|------|-------|-------|--------------|
+| #XXX | [PR Title](link) | [Error description] | [New ticket created: NOTIFY-XXX] |
+| #XXX | [PR Title](link) | [Error description] | [Manual code changes required] |
+
+### Dependabot PRs - Non-Resolvable ❌
+
+| Alert # | Title | Reason | Status |
+|---------|-------|--------|--------|
+| #115 | [brace-expansion Regular Expression Denial of Service vulnerability](https://github.com/bcgov/des-notifybc/security/dependabot/115) | Dependabot cannot update brace-expansion to a non-vulnerable version| Monitoring |
+| #XXX | [PR Title](link) | Formidable relies on hexoid to prevent guessing of filenames for untrusted executable content | Dependabot cannot update formidable to a non-vulnerable version |
+| #XXX | [Alert Title](link) | No patched version available | Monitoring |
+| #XXX | [Alert Title](link) | Breaking changes | Dismissed - not applicable |
+
+### Renovate PRs
+
+| PR # | Title | Status | Action |
+|------|-------|--------|--------|
+| #XXX | [PR Title](link) | ✅ Approved | All checks passed |
+| #XXX | [PR Title](link) | ⚠️ Flagged | [Reason] - Product owner notified |
+
+**Dependabot Dashboard:** <https://github.com/bcgov/des-notifybc/security/dependabot>
+
+---
+
+## 2. OWASP ZAP Scan Results
+
+### Scan Details
+
+- **Automatic Scan Date:** [DATE]
+- **API Scan Date:** [DATE]
+- **Target URLs:**
+  - [Production URL]
+  - [API Endpoints]
+
+### High-Risk Alerts Found
+
+| Alert | Risk Level | Description | Recommendation |
+|-------|------------|-------------|----------------|
+| [Alert Name] | High | [Description] | [Action required] |
+
+#### OR
+
+✅ **No high-risk alerts found**
+
+### Medium/Low Risk Summary
+
+- Medium Risk Alerts: X
+- Low Risk Alerts: X
+- Informational: X
+
+**Reports Attached:**
+
+- [OWASP_ZAP_Automatic_Scan_[DATE].html](attachment)
+- [OWASP_ZAP_API_Scan_[DATE].html](attachment)
+
+---
+
+## 3. Backup and Restore Verification
+
+### des-notifybc-prod
+- **Backup Date:** [DATE]
+- **Restore Test Date:** [DATE]
+- **Status:** ✅ Success / ❌ Failed
+- **Notes:** [Any issues or observations]
+
+### emcr-notifybc-prod
+- **Backup Date:** [DATE]
+- **Restore Test Date:** [DATE]
+- **Status:** ✅ Success / ❌ Failed
+- **Notes:** [Any issues or observations]
+
+**Reference:** [Backup and Restore Instructions](https://citz-gdx.atlassian.net/wiki/x/GYGtCQ)
+
+---
+
+## 4. Sysdig Alerts Review
+
+### Unresolved Alerts Since Last Maintenance
+
+| Alert ID | Severity | Description | Action Taken | Status |
+|----------|----------|-------------|--------------|--------|
+| [Alert ID] | Critical/High/Medium | [Description] | [Action description] | Resolved/Monitoring |
+
+**OR**
+
+✅ **No unresolved alerts found**
+
+### Severe Alerts Summary
+- Critical: X alerts
+- High: X alerts
+- Medium: X alerts
+
+**Sysdig Interface:** [Login instructions as per documentation](https://bitbucket.org/bc-gov/documentation/src/master/PlayBooks/Sysdig-Alerts/)
+
+---
+
+## 5. Inventory Updates
+
+### Changes Made This Period
+
+| Component | Previous Version | New Version | Change Type |
+|-----------|------------------|-------------|-------------|
+| [Software/Host] | [Version] | [Version] | Update/New/Removed |
+
+**OR**
+
+✅ **No inventory changes required - all items up to date**
+
+### Current Inventory Status
+- Hosts: [Status]
+- Platform: [Status]
+- Stack: [Status]
+- Software Versions: [Status]
+- Licenses: [Status]
+
+---
+
+## 6. Linked Issues Review
+
+### Issues Addressed
+- [NOTIFY-XXX]: [Description of action taken]
+- [NOTIFY-XXX]: [Description of action taken]
+
+**OR**
+
+✅ **No linked issues requiring action**
+
+---
+
+## Summary
+
+### Completion Status
+- [x] Dependabot/Renovate Review Complete
+- [x] OWASP ZAP Scans Complete
+- [x] Backup/Restore Verification Complete
+- [x] Sysdig Alerts Reviewed
+- [x] Inventory Updated
+- [x] Linked Issues Reviewed
+
+### Key Metrics
+- **Total PRs Merged:** X
+- **Security Alerts Resolved:** X
+- **High-Risk Issues Found:** X
+- **Systems Verified:** 2/2
+
+### Next Steps
+- [ ] Clone ticket for next maintenance cycle (due ~[NEXT DATE])
+- [ ] Ensure new ticket is assigned to NOTIFY project
+- [ ] Monitor any flagged issues with product owner
+- [ ] [Any specific follow-up actions]
+
+---
+
+## Attachments
+- OWASP ZAP Automatic Scan Report
+- OWASP ZAP API Scan Report
+- [Any additional documentation]
+
+---
+
+## References
+- **Dependabot Alerts:** https://github.com/bcgov/des-notifybc/security/dependabot
+- **OWASP ZAP Instructions:** https://bitbucket.org/bc-gov/documentation/src/master/PlayBooks/OWASP-ZAP/
+- **Backup Instructions:** https://citz-gdx.atlassian.net/wiki/x/GYGtCQ
+- **Sysdig Documentation:** https://bitbucket.org/bc-gov/documentation/src/master/PlayBooks/Sysdig-Alerts/
+- **Repository:** https://github.com/bcgov/des-notifybc

--- a/src/api/administrators/access-token.service.ts
+++ b/src/api/administrators/access-token.service.ts
@@ -35,9 +35,9 @@ export class AccessTokenService extends BaseService<AccessToken> {
   }
 
   async verifyToken(token: string): Promise<AdminUserProfile> {
-    if (!token) {
+    if (!token || typeof token !== 'string' || !/^[a-zA-Z0-9]{64}$/.test(token)) {
       throw new HttpException(
-        `Error verifying token : 'token' is null`,
+        `Error verifying token : 'token' is invalid`,
         HttpStatus.UNAUTHORIZED,
       );
     }

--- a/src/api/administrators/administrators.service.ts
+++ b/src/api/administrators/administrators.service.ts
@@ -33,9 +33,12 @@ export class AdministratorsService extends BaseService<Administrator> {
   async verifyCredentials(credentials: LoginDto): Promise<Administrator> {
     const invalidCredentialsError = 'Invalid email or password.';
 
+    if (typeof credentials.email !== 'string') {
+      throw new HttpException(invalidCredentialsError, HttpStatus.UNAUTHORIZED);
+    }
     const foundUser = await this.model
       .findOne({
-        email: credentials.email,
+        email: { $eq: credentials.email },
       })
       .populate('userCredential')
       .exec();

--- a/src/api/common/base.service.ts
+++ b/src/api/common/base.service.ts
@@ -95,7 +95,14 @@ export class BaseService<T> {
     }
     updateDto.updated = new Date();
     delete updateDto.id;
-    return this.model.findByIdAndUpdate(id, updateDto, options).exec();
+    
+    // Validate updateDto to ensure it is a plain object
+    if (typeof updateDto !== 'object' || Array.isArray(updateDto)) {
+      throw new Error('Invalid update data');
+    }
+    
+    // Use $set operator to safely update fields
+    return this.model.findByIdAndUpdate(id, { $set: updateDto }, options).exec();
   }
 
   replaceById(

--- a/src/api/notifications/notifications.controller.ts
+++ b/src/api/notifications/notifications.controller.ts
@@ -738,6 +738,15 @@ export class NotificationsController extends BaseController {
                 this.req.protocol + '://' + this.req.get('host');
             }
 
+            // Validate httpHost against an allow-list of trusted hosts
+            const trustedHosts = this.appConfig.trustedHosts || [];
+            if (!trustedHosts.some((trustedHost) => httpHost.startsWith(trustedHost))) {
+              throw new HttpException(
+                'Invalid host specified',
+                HttpStatus.BAD_REQUEST,
+              );
+            }
+
             const q = queue(async (task: { startIdx: string }) => {
               const uri =
                 httpHost +

--- a/src/api/subscriptions/subscriptions.controller.ts
+++ b/src/api/subscriptions/subscriptions.controller.ts
@@ -43,7 +43,7 @@ import {
 } from '@nestjs/swagger';
 import crypto from 'crypto';
 import { Request, Response } from 'express';
-import { merge } from 'lodash';
+import { merge, escapeRegExp as _escapeRegExp } from 'lodash';
 import { AnyObject, FilterQuery } from 'mongoose';
 import RandExp from 'randexp';
 import { Role } from 'src/auth/constants';
@@ -989,9 +989,10 @@ export class SubscriptionsController extends BaseController {
       !data.confirmationRequest.confirmationCode &&
       data.confirmationRequest.confirmationCodeRegex
     ) {
-      const confirmationCodeRegex = new RegExp(
+      const safeRegex = _.escapeRegExp(
         data.confirmationRequest.confirmationCodeRegex,
       );
+      const confirmationCodeRegex = new RegExp(safeRegex);
       data.confirmationRequest.confirmationCode = new RandExp(
         confirmationCodeRegex,
       ).gen();


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/des-notifybc/security/code-scanning/14](https://github.com/bcgov/des-notifybc/security/code-scanning/14)

To fix the SSRF vulnerability, we need to ensure that the `httpHost` value is validated or restricted to a predefined allow-list of trusted hosts. This prevents attackers from injecting malicious URLs via the `Host` header or other user-controlled inputs.

**Steps to fix:**
1. Introduce an allow-list of trusted hosts in the application configuration.
2. Validate the `httpHost` value against this allow-list before using it to construct the `uri`.
3. If the `httpHost` value is not in the allow-list, reject the request or use a default trusted host.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
